### PR TITLE
Fix labels in Summary File

### DIFF
--- a/volundr/Synthetic_Lethal.py
+++ b/volundr/Synthetic_Lethal.py
@@ -1055,10 +1055,11 @@ class SyntheticLethal:
             sample_indexed_reads = 0
 
             for line in temp_file:
-                sample_indexed_reads = int(line)
-                total_indexed_reads += int(line)
-                if index_name == "Unknown" or "GhostIndex":
+                if index_name == "Unknown" or index_name == "GhostIndex":
                     unknown_count += int(line)
+                else:
+                    sample_indexed_reads = int(line)
+                    total_indexed_reads += int(line)
 
             temp_file.close()
 


### PR DESCRIPTION
Summary file was not reporting unknown indexes correctly and labels for individual libraries were not correct.